### PR TITLE
Updates for compatibility with async-http

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ cache: bundler
 
 matrix:
   include:
-    - rvm: 2.0
-    - rvm: 2.1
-    - rvm: 2.2
     - rvm: 2.3
     - rvm: 2.4
     - rvm: jruby-head

--- a/async-http-faraday.gemspec
+++ b/async-http-faraday.gemspec
@@ -10,13 +10,11 @@ Gem::Specification.new do |spec|
 	spec.summary       = "Provides an adaptor between async-http and faraday."
 	spec.homepage      = "https://github.com/socketry/async-http"
 
-	spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-		f.match(%r{^(test|spec|features)/})
-	end
+	spec.files         = [".editorconfig", ".gitignore", ".rspec", ".travis.yml", "Gemfile", "README.md", "Rakefile", "async-http-faraday.gemspec", "lib/async/http/faraday.rb", "lib/async/http/faraday/adapter.rb", "lib/async/http/faraday/version.rb"]
 	spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
 	spec.require_paths = ["lib"]
 	
-	spec.add_dependency("async-http", "~> 0.5")
+	spec.add_dependency("async-http", "~> 0.37")
 	spec.add_dependency("faraday")
 	
 	spec.add_development_dependency "async-rspec", "~> 1.2"

--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -29,9 +29,9 @@ module Async
 				def call(env)
 					super
 					
-					client = HTTP::Client.new(endpoints_for(env).to_a)
+					client = HTTP::Client.new(*endpoints_for(env).to_a)
 					
-					response = client.send_request(env[:method], env[:url].request_uri, env[:request_headers], env[:body] || [])
+					response = client.send(env[:method], env[:url].request_uri, env[:request_headers], env[:body] || [])
 					
 					save_response(env, response.status, response.body, response.headers, response.reason)
 					
@@ -42,16 +42,7 @@ module Async
 					return to_enum(:endpoints_for, env) unless block_given?
 					
 					if url = env[:url]
-						port = url.port
-						port ||= url.scheme == 'https' ? 443 : 80
-						
-						endpoint = Async::IO::Endpoint.tcp(url.hostname, port)
-						
-						if url.scheme == 'https'
-							yield SecureEndpoint.new(endpoint, ssl_context: ssl_context_for(env[:ssl]))
-						else
-							yield endpoint
-						end
+						yield Async::HTTP::URLEndpoint.new(url)
 					end
 				end
 				


### PR DESCRIPTION
These changes make `async-http-faraday` compatible with `async-http` v0.36.2, which is required by `falcon`. I'm not sure they are the best fixes, but it works for me locally.