### PR TITLE
make response body a string

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -33,7 +33,7 @@ module Async
 					
 					response = client.send(env[:method], env[:url].request_uri, env[:request_headers], env[:body] || [])
 					
-					save_response(env, response.status, response.body, response.headers, response.reason)
+					save_response(env, response.status, response.body.read, response.headers, response.reason)
 					
 					@app.call env
 				end

--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Async::HTTP::Faraday::Adapter do
 			
 			response = conn.get("/index")
 			
-			expect(response.body.read).to be == "Hello World"
+			expect(response.body).to be == "Hello World"
 			
 			server_task.stop
 		end


### PR DESCRIPTION
gems that uses `faraday` expects that response body will be a String

when it's not we receive strange errors like that

```
Started GET "/api/rest/charts/example_charts" for ::1 at 2019-03-25 16:34:18 +0200
Processing by Api::Rest::Charts::Cdrs::QtyController# as */*
undefined method `strip' for #<Async::HTTP::Body::Chunked 0 bytes read in 0 chunks>
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/clickhouse-0.1.10/lib/clickhouse/connection/client.rb:80:in `parse_body'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/clickhouse-0.1.10/lib/clickhouse/connection/client.rb:66:in `request'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/clickhouse-0.1.10/lib/clickhouse/connection/client.rb:26:in `get'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/clickhouse-0.1.10/lib/clickhouse/connection/query.rb:17:in `query'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/clickhouse-0.1.10/lib/clickhouse/cluster.rb:36:in `block in method_missing'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/pond-0.3.0/lib/pond.rb:76:in `checkout_object'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/pond-0.3.0/lib/pond.rb:41:in `checkout'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/clickhouse-0.1.10/lib/clickhouse/cluster.rb:35:in `method_missing'
/home/senid/projects/my_app/app/lib/click_house/db.rb:17:in `execute'
/home/senid/projects/my_app/app/lib/click_house/db.rb:13:in `to_hashes'
/home/senid/projects/my_app/app/models/charts/click_house_chart/base.rb:45:in `collection'
/home/senid/projects/my_app/app/models/charts/click_house_chart/base.rb:50:in `normalize_collection'
/home/senid/projects/my_app/app/models/charts/click_house_chart/base.rb:36:in `data_chart'
/home/senid/projects/my_app/app/controllers/api/rest/charts/example_charts_controller.rb:10:in `index'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_controller/metal/basic_implicit_render.rb:6:in `send_action'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/abstract_controller/base.rb:194:in `process_action'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_controller/metal/rendering.rb:30:in `process_action'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/abstract_controller/callbacks.rb:42:in `block in process_action'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activesupport-5.2.2.1/lib/active_support/callbacks.rb:132:in `run_callbacks'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/abstract_controller/callbacks.rb:41:in `process_action'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_controller/metal/rescue.rb:22:in `process_action'
/home/senid/projects/my_app/patches/active_controller_instrumentation.rb:28:in `block in process_action'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activesupport-5.2.2.1/lib/active_support/notifications.rb:168:in `block in instrument'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activesupport-5.2.2.1/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activesupport-5.2.2.1/lib/active_support/notifications.rb:168:in `instrument'
/home/senid/projects/my_app/patches/active_controller_instrumentation.rb:26:in `process_action'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_controller/metal/params_wrapper.rb:256:in `process_action'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activerecord-5.2.2.1/lib/active_record/railties/controller_runtime.rb:24:in `process_action'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/abstract_controller/base.rb:134:in `process'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionview-5.2.2.1/lib/action_view/rendering.rb:32:in `process'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_controller/metal.rb:191:in `dispatch'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_controller/metal.rb:252:in `dispatch'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/routing/route_set.rb:52:in `dispatch'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/routing/route_set.rb:34:in `serve'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/journey/router.rb:52:in `block in serve'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/journey/router.rb:35:in `each'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/journey/router.rb:35:in `serve'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/routing/route_set.rb:840:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/railties-5.2.2.1/lib/rails/engine.rb:524:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/railties-5.2.2.1/lib/rails/railtie.rb:190:in `public_send'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/railties-5.2.2.1/lib/rails/railtie.rb:190:in `method_missing'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/routing/mapper.rb:19:in `block in <class:Constraints>'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/routing/mapper.rb:48:in `serve'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/journey/router.rb:52:in `block in serve'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/journey/router.rb:35:in `each'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/journey/router.rb:35:in `serve'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/routing/route_set.rb:840:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/bullet-5.9.0/lib/bullet/rack.rb:12:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/rack-2.0.6/lib/rack/tempfile_reaper.rb:15:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/rack-2.0.6/lib/rack/etag.rb:25:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/rack-2.0.6/lib/rack/conditional_get.rb:25:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/rack-2.0.6/lib/rack/head.rb:12:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/http/content_security_policy.rb:18:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/rack-2.0.6/lib/rack/session/abstract/id.rb:232:in `context'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/rack-2.0.6/lib/rack/session/abstract/id.rb:226:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/cookies.rb:670:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activerecord-5.2.2.1/lib/active_record/migration.rb:559:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activesupport-5.2.2.1/lib/active_support/callbacks.rb:98:in `run_callbacks'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/callbacks.rb:26:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/debug_exceptions.rb:61:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/railties-5.2.2.1/lib/rails/rack/logger.rb:38:in `call_app'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/railties-5.2.2.1/lib/rails/rack/logger.rb:26:in `block in call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activesupport-5.2.2.1/lib/active_support/tagged_logging.rb:71:in `block in tagged'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activesupport-5.2.2.1/lib/active_support/tagged_logging.rb:28:in `tagged'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activesupport-5.2.2.1/lib/active_support/tagged_logging.rb:71:in `tagged'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/railties-5.2.2.1/lib/rails/rack/logger.rb:26:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/sprockets-rails-3.2.1/lib/sprockets/rails/quiet_assets.rb:13:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/request_store-1.4.0/lib/request_store/middleware.rb:19:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/request_id.rb:27:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/rack-2.0.6/lib/rack/method_override.rb:22:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/rack-2.0.6/lib/rack/runtime.rb:22:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/activesupport-5.2.2.1/lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/executor.rb:14:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/actionpack-5.2.2.1/lib/action_dispatch/middleware/static.rb:127:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/rack-2.0.6/lib/rack/sendfile.rb:111:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/railties-5.2.2.1/lib/rails/engine.rb:524:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/falcon-0.26.0/lib/falcon/adapters/rack.rb:185:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/bundler/gems/async-http-a4f659f40d18/lib/async/http/middleware.rb:57:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/falcon-0.26.0/lib/falcon/adapters/rewindable.rb:61:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/bundler/gems/async-http-a4f659f40d18/lib/async/http/middleware.rb:57:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/bundler/gems/async-http-a4f659f40d18/lib/async/http/content_encoding.rb:44:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/bundler/gems/async-http-a4f659f40d18/lib/async/http/middleware.rb:57:in `call'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/bundler/gems/async-http-a4f659f40d18/lib/async/http/server.rb:61:in `block in accept'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/bundler/gems/async-http-a4f659f40d18/lib/async/http/protocol/http1/server.rb:55:in `each'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/bundler/gems/async-http-a4f659f40d18/lib/async/http/server.rb:50:in `accept'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/async-io-1.20.0/lib/async/io/socket.rb:98:in `block in accept_each'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/async-io-1.20.0/lib/async/io/socket.rb:134:in `block in accept'
/home/senid/.rvm/gems/ruby-2.3.8-railsexpress@my_app/gems/async-1.17.0/lib/async/task.rb:204:in `block in make_fiber'
Completed 500 Internal Server Error in 6111ms (ActiveRecord: 1.1ms)
```