### PR TITLE
Make compatible with recent async-http gem

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -33,7 +33,7 @@ module Async
 					
 					response = client.send(env[:method], env[:url].request_uri, env[:request_headers], env[:body] || [])
 					
-					save_response(env, response.status, response.body.read, response.headers, response.reason)
+					save_response(env, response.status, response.body.read, response.headers)
 					
 					@app.call env
 				end
@@ -42,7 +42,7 @@ module Async
 					return to_enum(:endpoints_for, env) unless block_given?
 					
 					if url = env[:url]
-						yield Async::HTTP::URLEndpoint.new(url)
+						yield Async::HTTP::Endpoint.new(url)
 					end
 				end
 				

--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -26,7 +26,7 @@ require 'async/reactor'
 
 RSpec.describe Async::HTTP::Faraday::Adapter do
 	let(:endpoint) {
-		Async::HTTP::URLEndpoint.parse('http://127.0.0.1:9294')
+		Async::HTTP::Endpoint.parse('http://127.0.0.1:9294')
 	}
 
 	it "client can get resource" do

--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -19,9 +19,8 @@
 # THE SOFTWARE.
 
 require 'async/http/faraday'
-require 'async/http/response'
 require 'async/http/server'
-require 'async/http/url_endpoint'
+require 'async/http/endpoint'
 require 'async/reactor'
 
 RSpec.describe Async::HTTP::Faraday::Adapter do
@@ -31,7 +30,7 @@ RSpec.describe Async::HTTP::Faraday::Adapter do
 
 	it "client can get resource" do
 		app = ->(request) do
-			Async::HTTP::Response[200, {}, ["Hello World"]]
+			Protocol::HTTP::Response[200, {}, ["Hello World"]]
 		end
 
 		server = Async::HTTP::Server.new(app, endpoint)


### PR DESCRIPTION
This pull request makes `async-http-faraday` compatible with `async-http` gem (as of 0.48.2 version).

- use `Async::HTTP::Endpoint` instead of `Async::HTTP::URLEndpoint`
- do not use `response.reason`