### PR TITLE
Fix chunked and no content responses

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -32,8 +32,8 @@ module Async
 					client = HTTP::Client.new(*endpoints_for(env).to_a)
 					
 					response = client.send(env[:method], env[:url].request_uri, env[:request_headers], env[:body] || [])
-					
-					save_response(env, response.status, response.body.read, response.headers)
+
+					save_response(env, response.status, response.body && response.body.join, response.headers)
 					
 					@app.call env
 				end

--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -33,7 +33,7 @@ module Async
 					
 					response = client.send(env[:method], env[:url].request_uri, env[:request_headers], env[:body] || [])
 
-					save_response(env, response.status, response.body && response.body.join, response.headers)
+					save_response(env, response.status, response.read, response.headers)
 					
 					@app.call env
 				end

--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -29,41 +29,61 @@ RSpec.describe Async::HTTP::Faraday::Adapter do
 		Async::HTTP::Endpoint.parse('http://127.0.0.1:9294')
 	}
 
-	it "client can get resource" do
-		app = ->(request) do
-			Protocol::HTTP::Response[200, {}, ["Hello World"]]
+	def run_server(response)
+		Async do |task|
+			begin
+				server_task = task.async do
+					app = ->(_) { response }
+					Async::HTTP::Server.new(app, endpoint).run
+				end
+
+				yield
+			ensure
+				server_task.stop
+			end
+		end.wait
+	end
+
+	def get_response(url, path)
+		connection = Faraday.new(url: url) do |faraday|
+			faraday.response :logger
+			faraday.adapter :async_http
 		end
 
-		server = Async::HTTP::Server.new(app, endpoint)
+		connection.get(path)
+	end
+
+	it "client can get resource" do
+		run_server(Protocol::HTTP::Response[200, {}, ['Hello World']]) do
+			response = get_response(endpoint.url, '/index')
 		
-		Async do |task|
-			server_task = task.async do
-				server.run
-			end
-			
-			connection = Faraday.new(:url => endpoint.url) do |faraday|
-				faraday.response :logger
-				faraday.adapter :async_http
-			end
-			
-			response = connection.get("/index")
-			
-			expect(response.body).to be == "Hello World"
-			
-			server_task.stop
+			expect(response.body).to eq 'Hello World'
 		end
 	end
 	
 	it "can get remote resource" do
-		Async do |task|
-			connection = Faraday.new(:url => "http://www.google.com") do |faraday|
-				faraday.response :logger
-				faraday.adapter :async_http
-			end
-			
-			response = connection.get("/search?q=cats")
+		Async do
+			response = get_response('http://www.google.com', '/search?q=cats')
 			
 			expect(response).to be_success
+		end
+	end
+
+	it 'properly handles chunked responses' do
+		large_response_size = 65536
+
+		run_server(Protocol::HTTP::Response[200, {}, ['.' * large_response_size]]) do
+			response = get_response(endpoint.url, '/index')
+
+			expect(response.body.size).to eq large_response_size
+		end
+	end
+
+	it 'properly handles no content responses' do
+		run_server(Protocol::HTTP::Response[204]) do
+			response = get_response(endpoint.url, '/index')
+
+			expect(response.body).to be_nil
 		end
 	end
 end


### PR DESCRIPTION
This pull request fixes a few issues with some special response types:

- For large responses, only the first response chunk (with size of ~8kb) was returned in response body
- If the response was `204 No Content` with no body, the adapter was choking with `NoMethodError: undefined method 'read' for nil:NilClass error`