### PR TITLE
Fix leaking sockets

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -36,6 +36,8 @@ module Async
 					save_response(env, response.status, response.read, response.headers)
 					
 					@app.call env
+				ensure
+					client.close if client
 				end
 				
 				def endpoints_for(env)

--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -25,6 +25,8 @@ require 'async/http/endpoint'
 require 'async'
 
 RSpec.describe Async::HTTP::Faraday::Adapter do
+	include_context Async::RSpec::Reactor
+
 	let(:endpoint) {
 		Async::HTTP::Endpoint.parse('http://127.0.0.1:9294')
 	}
@@ -84,27 +86,6 @@ RSpec.describe Async::HTTP::Faraday::Adapter do
 			response = get_response(endpoint.url, '/index')
 
 			expect(response.body).to be_nil
-		end
-	end
-
-	if RbConfig::CONFIG['host_os'] =~ /linux/
-		it 'does not leak sockets' do
-			def get_socket_count
-				`ls -l /proc/#{$$}/fd | grep socket | wc -l`.to_i
-			end
-
-			REQUEST_COUNT = 3
-
-			run_server(Protocol::HTTP::Response[204]) do
-				# warm up
-				get_response(endpoint.url, '/index')
-
-				sockets_before = get_socket_count
-				REQUEST_COUNT.times { get_response(endpoint.url, '/index') }
-				sockets_after = get_socket_count
-
-				expect(sockets_after).to eq sockets_before
-			end
 		end
 	end
 end

--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -93,16 +93,17 @@ RSpec.describe Async::HTTP::Faraday::Adapter do
 				`ls -l /proc/#{$$}/fd | grep socket | wc -l`.to_i
 			end
 
-			REQUEST_COUNT = 100
+			REQUEST_COUNT = 3
 
 			run_server(Protocol::HTTP::Response[204]) do
+				# warm up
+				get_response(endpoint.url, '/index')
+
 				sockets_before = get_socket_count
-
 				REQUEST_COUNT.times { get_response(endpoint.url, '/index') }
-
 				sockets_after = get_socket_count
 
-				expect(sockets_after - sockets_before).to be < REQUEST_COUNT
+				expect(sockets_after).to eq sockets_before
 			end
 		end
 	end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 
+require 'async/rspec'
 require 'covered/rspec'
 
 RSpec.configure do |config|


### PR DESCRIPTION
This pull request fixes an issue with adapter leaking a socket with each request. If the adapter is used in a long running process making a lot of requests, it will eventually exceed maximum open file descriptors limit and start to fail with `Errno::EMFILE (Too many open files - socket(2))` exception.

Unfortunately I only have Linux hardware at hand, and I'm not sure if this issue is present on other platforms, so the spec I wrote is only applicable for Linux.
