### PR TITLE
Add persistent option to allow automatic connection closing

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -25,14 +25,12 @@ require 'async/http/internet'
 module Async
 	module HTTP
 		module Faraday
-			# Detect whether we can use persistent connections:
-			PERSISTENT = ::Faraday::Connection.instance_methods.include?(:close)
-			
 			class Adapter < ::Faraday::Adapter
 				def initialize(*arguments, **options, &block)
 					super
 					
 					@internet = Async::HTTP::Internet.new
+					@persistent = ::Faraday::Connection.instance_methods.include?(:close) && options.fetch(:persistent, true)
 				end
 				
 				def close
@@ -49,7 +47,7 @@ module Async
 					return @app.call(env)
 				ensure
 					# Don't retain persistent connections unless they will eventually be closed:
-					@internet.close unless PERSISTENT
+					@internet.close unless @persistent
 				end
 			end
 		end

--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -27,7 +27,7 @@ module Async
 		module Faraday
 			# Detect whether we can use persistent connections:
 			PERSISTENT = ::Faraday::Connection.instance_methods.include?(:close)
-
+			
 			class Adapter < ::Faraday::Adapter
 				def initialize(*arguments, **options, &block)
 					super

--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -25,12 +25,15 @@ require 'async/http/internet'
 module Async
 	module HTTP
 		module Faraday
+			# Detect whether we can use persistent connections:
+			PERSISTENT = ::Faraday::Connection.instance_methods.include?(:close)
+
 			class Adapter < ::Faraday::Adapter
 				def initialize(*arguments, **options, &block)
 					super
 					
 					@internet = Async::HTTP::Internet.new
-					@persistent = ::Faraday::Connection.instance_methods.include?(:close) && options.fetch(:persistent, true)
+					@persistent = PERSISTENT && options.fetch(:persistent, true)
 				end
 				
 				def close

--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -91,4 +91,13 @@ RSpec.describe Async::HTTP::Faraday::Adapter do
 			expect(response.body).to be_nil
 		end
 	end
+
+	it 'closes connection automatically if persistent option is set to false' do
+		run_server(Protocol::HTTP::Response[204]) do
+			Faraday.new(url: endpoint.url) do |faraday|
+				faraday.response :logger
+				faraday.adapter :async_http, persistent: false
+			end.get('/index')
+		end
+	end
 end


### PR DESCRIPTION
This PR adds new option `persistent` to the adapter (`true` by default), which if set to `false` will use the old connection closing policy - the connection will be opened and closed for every request, no manual closing needed.