### PR TITLE
wrap connection and timeout exceptions

### DIFF
--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -100,4 +100,8 @@ RSpec.describe Async::HTTP::Faraday::Adapter do
 			end.get('/index')
 		end
 	end
+
+	it 'wraps underlying exceptions into Faraday analogs' do
+		expect { get_response(endpoint.url, '/index') }.to raise_error(Faraday::ConnectionFailed)
+	end
 end


### PR DESCRIPTION
This PR implements exception wrapping: any underlying exceptions caused by broken connection, timeouts, etc. are wrapped in Faraday exception classes.

The list of exceptions is based on the one used in NetHttp adapter (https://github.com/lostisland/faraday/blob/master/lib/faraday/adapter/net_http.rb). I'm not sure all of the exceptions are relevant and if other ones (like for example `Protocol::HTTP*::*Error` or `Async::HTTP::Protocol::RequestFailed` or smth like that) should be included. The most common unwrapped exceptions that I've stumbled upon while using this adapter were `Errno::ETIMEDOUT`, `Errno::ECONNREFUSED` and `Errno::EHOSTUNREACH`.