### PR TITLE
HTTP methods should be uppercase

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -43,7 +43,7 @@ module Async
 				def call(env)
 					super
 					
-					response = @internet.call(env[:method], env[:url].to_s, env[:request_headers], env[:body])
+					response = @internet.call(env[:method].to_s.upcase, env[:url].to_s, env[:request_headers], env[:body])
 					
 					save_response(env, response.status, response.read, response.headers)
 					


### PR DESCRIPTION
This PR fixes following issue that appeared with transition from `Async::HTTP::Client` to `Async::HTTP::Internet`:

`env[:method]` is being passed unmodified to `@internet.call` and further down the chain to `Protocol::HTTP1::Connection#write_request` that sends the data to remote server:
```
def write_request(authority, method, path, version, headers)
  @stream.write("#{method} #{path} #{version}\r\n")
```
The issue is that HTTP methods have to be uppercase, but `env[:method]` is a lowercase symbol, that originates from `Faraday::Connection::METHODS` (https://github.com/lostisland/faraday/blob/master/lib/faraday/connection.rb)
```
# A Set of allowed HTTP verbs.
METHODS = Set.new %i[get post put delete head patch options trace]
```

I didn't write any new specs, as the "can get remote resource" spec was failing for me because of this issue:
```
  1) Async::HTTP::Faraday::Adapter can get remote resource                         
     Failure/Error: expect(response).to be_success                
       expected `#<Faraday::Response:0x000055ba90889370 @on_complete_callbacks=[], @env=#<Faraday::Env @method=:get @u...> is inappropriate for the URL <code>/search</code>.  <ins>That\xE2\x80\x99s all we know.</ins>\n">>.success?` to return true, got false
     # ./spec/async/http/faraday/adapter_spec.rb:73:in `block (3 levels) in <top (required)>'
     # ./vendor/ruby/2.6.0/gems/async-1.24.1/lib/async/task.rb:256:in `block in make_fiber'
```
It is passing now. Not sure why this error was not happening on CI - does it make real requests to google?