### PR TITLE
add timeout option

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -41,10 +41,6 @@ module Async
 					IOError,
 					SocketError
 				].freeze
-				TIMEOUT_EXCEPTIONS = [
-					Errno::ETIMEDOUT,
-					Async::TimeoutError
-				].freeze
 
 				def initialize(*arguments, **options, &block)
 					super
@@ -68,7 +64,7 @@ module Async
 					end
 					
 					return @app.call(env)
-				rescue *TIMEOUT_EXCEPTIONS => e
+				rescue Errno::ETIMEDOUT => e
 					raise ::Faraday::TimeoutError, e
 				rescue OpenSSL::SSL::SSLError => e
 					raise ::Faraday::SSLError, e
@@ -83,7 +79,7 @@ module Async
 
 				def with_timeout
 					if @timeout
-						Async::Task.current.with_timeout(@timeout) do
+						Async::Task.current.with_timeout(@timeout, ::Faraday::TimeoutError) do
 							yield
 						end
 					else


### PR DESCRIPTION
This PR adds `timeout` option to the adapter: if the request takes more time than the `timeout` (in seconds), `Faraday::TimeoutError` is raised. Default value of `timeout` is `nil`, that is consistent with the old behaviour where no timeout is applied.