### PR TITLE
Fix/cast request method to string

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -117,7 +117,7 @@ module Async
 							headers = ::Protocol::HTTP::Headers[headers]
 						end
 						
-						method = env.method.upcase.to_s
+						method = env.method.to_s.upcase
 						
 						request = ::Protocol::HTTP::Request.new(endpoint.scheme, endpoint.authority, method, endpoint.path, nil, headers, body)
 						

--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -117,7 +117,7 @@ module Async
 							headers = ::Protocol::HTTP::Headers[headers]
 						end
 						
-						method = env.method.upcase
+						method = env.method.upcase.to_s
 						
 						request = ::Protocol::HTTP::Request.new(endpoint.scheme, endpoint.authority, method, endpoint.path, nil, headers, body)
 						


### PR DESCRIPTION
Currently, `HEAD` requests don't work. Requests made with this method always get stuck.

It happens because this [implementation](https://github.com/socketry/protocol-http1/blob/main/lib/protocol/http1/connection.rb#L433) uses equality conditional, nowadays comparing the symbol `:HEAD `and the string `"HEAD"`.

This PR casts the symbol to a string.

### Types of Changes

- Bug fix.

### Testing

- [x] I tested my changes locally.