### PR TITLE
Honor Content-Type charset

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -149,10 +149,10 @@ module Async
 					end
 				end
 				
-				def encoded_body(res)
-					body = res.read
+				def encoded_body(response)
+					body = response.read
 					return body if body.nil?
-					content_type = res.headers['content-type']
+					content_type = response.headers['content-type']
 					/\bcharset=\s*(.+?)\s*(;|$)/.match(content_type) do |match|
 						content_charset = Encoding.find(match.captures.first)
 						body = body.dup if body.frozen?

--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -124,7 +124,7 @@ module Async
 						with_timeout do
 							response = client.call(request)
 							
-							save_response(env, response.status, response.read, response.headers)
+							save_response(env, response.status, encoded_body(response), response.headers)
 						end
 					end
 					
@@ -147,6 +147,20 @@ module Async
 					else
 						yield
 					end
+				end
+				
+				def encoded_body(res)
+					body = res.read
+					return body if body.nil?
+					content_type = res.headers['content-type']
+					/\bcharset=\s*(.+?)\s*(;|$)/.match(content_type) do |match|
+						content_charset = Encoding.find(match.captures.first)
+						body = body.dup if body.frozen?
+						body.force_encoding(content_charset)
+					rescue ArgumentError
+						nil
+					end
+					body
 				end
 			end
 		end

--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -154,7 +154,7 @@ module Async
 					return body if body.nil?
 					content_type = response.headers['content-type']
 					return body unless content_type
-					params = type_params(content_type)
+					params = extract_type_parameters(content_type)
 					if charset = params['charset']
 						body = body.dup if body.frozen?
 						body.force_encoding(charset)
@@ -164,13 +164,13 @@ module Async
 					nil
 				end
 				
-				def type_params(content_type)
+				def extract_type_parameters(content_type)
 					result = {}
 					list = content_type.split(';')
 					list.shift
 					list.each do |param|
-						k, v = *param.split('=', 2)
-						result[k.strip] = v.strip
+						key, value = *param.split('=', 2)
+						result[key.strip] = value.strip
 					end
 					result
 				end

--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -153,14 +153,26 @@ module Async
 					body = response.read
 					return body if body.nil?
 					content_type = response.headers['content-type']
-					/\bcharset=\s*(.+?)\s*(;|$)/.match(content_type) do |match|
-						content_charset = Encoding.find(match.captures.first)
+					return body unless content_type
+					params = type_params(content_type)
+					if charset = params['charset']
 						body = body.dup if body.frozen?
-						body.force_encoding(content_charset)
-					rescue ArgumentError
-						nil
+						body.force_encoding(charset)
 					end
 					body
+				rescue ArgumentError
+					nil
+				end
+				
+				def type_params(content_type)
+					result = {}
+					list = content_type.split(';')
+					list.shift
+					list.each do |param|
+						k, v = *param.split('=', 2)
+						result[k.strip] = v.strip
+					end
+					result
 				end
 			end
 		end

--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -72,6 +72,15 @@ RSpec.describe Async::HTTP::Faraday::Adapter do
 			expect(get_response.body).to eq 'Hello World'
 		end
 	end
+
+  it "client can get responce with respect to Content-Type encoding" do
+    run_server(Protocol::HTTP::Response[200, {'Content-Type' => 'text/html; charset=utf-8'}, ['こんにちは世界']]) do
+      body = get_response.body
+      expect(body.encoding).to eq Encoding::UTF_8
+      expect(body).to eq 'こんにちは世界'
+    end
+  end
+
 	
 	it "works without top level reactor" do
 		response = get_response("https://www.google.com", "/search?q=ruby")


### PR DESCRIPTION
Fixed the encoding of the response body so that honors to the encoding in the `Content-Type`.
cf.) https://github.com/lostisland/faraday-net_http/pull/13

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
