### PR TITLE
Set the path to `/` if it is empty in order to be compatible with default adapter

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -99,6 +99,9 @@ module Async
 				def call(env)
 					super
 					
+					# for compatibility with the default adapter
+					env.url.path = '/' if env.url.path.empty?
+					
 					Sync do
 						endpoint = Endpoint.new(env.url)
 						

--- a/spec/async/http/faraday/adapter_spec.rb
+++ b/spec/async/http/faraday/adapter_spec.rb
@@ -87,6 +87,13 @@ RSpec.describe Async::HTTP::Faraday::Adapter do
 		end
 	end
 	
+	it "works without initial url and trailing slash (compatiblisity to the original behaviour)" do
+		response = Faraday.new do |faraday|
+			faraday.adapter :async_http
+		end.get 'https://www.google.com'
+		expect(response).to be_success
+	end
+	
 	it 'properly handles chunked responses' do
 		large_response_size = 65536
 		


### PR DESCRIPTION
Working with the default adapter, it can get URL which has no trailing slash even when it is initialized no url.
To be compatible with that behaviour, I set the request path to '/' if it is empty.
Now this code works correctly.

```ruby
response = Faraday.new do |faraday|
  faraday.adapter :async_http
end.get 'https://www.google.com'
```

## Types of Changes

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
