### PR TITLE
Fix handling of string bodies.

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -18,7 +18,7 @@ require 'async/http/proxy'
 module Async
 	module HTTP
 		module Faraday
-			class BodyWrapper < ::Protocol::HTTP::Body::Readable
+			class BodyReadWrapper < ::Protocol::HTTP::Body::Readable
 				def initialize(body, block_size: 4096)
 					@body = body
 					@block_size = block_size
@@ -118,8 +118,11 @@ module Async
 						if body = env.body
 							# We need to wrap the body in a Readable object so that it can be read in chunks:
 							# Faraday's body only responds to `#read`.
-							# body = ::Protocol::HTTP::Body::Buffered.wrap(body)
-							body = BodyWrapper.new(body)
+							if body.respond_to?(:read)
+								body = BodyReadWrapper.new(body)
+							else
+								body = ::Protocol::HTTP::Body::Buffered.wrap(body)
+							end
 						end
 						
 						if headers = env.request_headers

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ require 'async/http/faraday'
 Faraday.default_adapter = :async_http
 
 # Per connection:
-conn = Faraday.new(...) do |faraday|
-	faraday.adapter :async_http
+connection = Faraday.new(...) do |builder|
+	builder.adapter :async_http
 end
 ```
 
@@ -40,7 +40,7 @@ Here is how you make a request:
 
 ``` ruby
 Async do
-	response = conn.get("/index")
+	response = connection.get("/index")
 end
 ```
 

--- a/spec/async/http/faraday/adapter/proxy_spec.rb
+++ b/spec/async/http/faraday/adapter/proxy_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Async::HTTP::Faraday::Adapter, if: ENV.key?('PROXY_URL') do
 	include_context Async::RSpec::Reactor
 	
 	def get_response(url = endpoint.url, path = '/index', adapter_options: {})
-		connection = Faraday.new(url, proxy: ENV['PROXY_URL']) do |faraday|
-			faraday.response :logger
-			faraday.adapter :async_http, **adapter_options
+		connection = Faraday.new(url, proxy: ENV['PROXY_URL']) do |builder|
+			builder.response :logger
+			builder.adapter :async_http, **adapter_options
 		end
 		
 		connection.get(path)


### PR DESCRIPTION
<https://github.com/socketry/async-http-faraday/pull/33> wasn't completely correct, we must also handle `String` bodies.

See <https://github.com/socketry/async-http-faraday/issues/36> for more context/failures.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
