### PR TITLE
Don't wrap request bodies if they are already Readables

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -153,7 +153,7 @@ module Async
 						end
 						
 						if body = env.body
-							# We need to wrap the body in a Readable object so that it can be read in chunks:
+							# We need to ensure the body is wrapped in a Readable object so that it can be read in chunks:
 							# Faraday's body only responds to `#read`.
 							if body.is_a?(::Protocol::HTTP::Body::Readable)
 								# Good to go

--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -118,7 +118,9 @@ module Async
 						if body = env.body
 							# We need to wrap the body in a Readable object so that it can be read in chunks:
 							# Faraday's body only responds to `#read`.
-							if body.respond_to?(:read)
+							if body.is_a?(::Protocol::HTTP::Body::Readable)
+								# Good to go
+							elsif body.respond_to?(:read)
 								body = BodyReadWrapper.new(body)
 							else
 								body = ::Protocol::HTTP::Body::Buffered.wrap(body)

--- a/test/async/http/faraday/adapter.rb
+++ b/test/async/http/faraday/adapter.rb
@@ -129,13 +129,13 @@ describe Async::HTTP::Faraday::Adapter do
 			end
 
 			it "can use a ::Protocol::HTTP::Body::Readable body" do
-				readable = ::Protocol::HTTP::Body::File.new(File.open(__FILE__, 'r'), 0..128)
+				readable = ::Protocol::HTTP::Body::File.new(File.open(__FILE__, 'r'), 0...128)
 
 				response = Faraday.new do |builder|
 					builder.adapter :async_http
 				end.post(bound_url, readable)
 
-				expect(response.body).to be == File.read(__FILE__, 129)
+				expect(response.body).to be == File.read(__FILE__, 128)
 			end
 		end
 	end

--- a/test/async/http/faraday/adapter.rb
+++ b/test/async/http/faraday/adapter.rb
@@ -15,6 +15,8 @@ require 'sus/fixtures/async/http/server_context'
 require 'faraday'
 require 'faraday/multipart'
 
+require 'protocol/http/body/file'
+
 describe Async::HTTP::Faraday::Adapter do
 	def get_response(url = bound_url, path = '/index', adapter_options: {})
 		connection = Faraday.new(url) do |builder|
@@ -124,6 +126,16 @@ describe Async::HTTP::Faraday::Adapter do
 				end.post(bound_url, text: 'Hello World')
 				
 				expect(response.body).to be == 'text=Hello+World'
+			end
+
+			it "can use a ::Protocol::HTTP::Body::Readable body" do
+				readable = ::Protocol::HTTP::Body::File.new(File.open(__FILE__, 'r'), 0..128)
+
+				response = Faraday.new do |builder|
+					builder.adapter :async_http
+				end.post(bound_url, readable)
+
+				expect(response.body).to be == File.read(__FILE__, 129)
 			end
 		end
 	end


### PR DESCRIPTION
We don't need to wrap request bodies if they already conform to the `::Protocol::HTTP::Body::Readable` interface. This way developers can use other kinds of `Readable`s directly when making calls with `Faraday`.

Use-case: We need to make several requests to an API with chunks of a file in specific byte ranges. `Protocol::HTTP::Body::File` (from https://github.com/socketry/protocol-http) seems like a good candidate for this:
```ruby
file_io = URI(file_url).open
byte_ranges.each do |first_byte, last_byte|
  body = Protocol::HTTP::Body::File.new(file_io, first_byte..last_byte)
  Faraday.post("https://example.com/uploads", body)
end
```

## Types of Changes

- New feature.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
