### PR TITLE
Represent empty body response as blank string.

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -234,7 +234,7 @@ module Async
 				
 				def encoded_body(response)
 					body = response.read
-					return body if body.nil?
+					return +'' if body.nil?
 					content_type = response.headers['content-type']
 					return body unless content_type
 					params = extract_type_parameters(content_type)

--- a/test/async/http/faraday/adapter.rb
+++ b/test/async/http/faraday/adapter.rb
@@ -101,7 +101,8 @@ describe Async::HTTP::Faraday::Adapter do
 			end
 			
 			it "properly handles no content responses" do
-				expect(get_response.body).to be_nil
+				expect(get_response.body).to be == ''
+				expect(get_response.body).not.to be(:frozen?)
 			end
 		end
 		


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->
Faraday adapters are expected to [represent empty body response as blank string](https://github.com/lostisland/faraday/blob/a9cf00425e3abc99b78952af44deb2912a65a882/spec/support/shared_examples/request_method.rb#L45-L47) and this PR aligns async-http-faraday to this specification, fixing #46.

Moreover, the returned blank string is unfreezed, in the same way the "reference implementation" of [the faraday-net_http adapter is doing it](https://github.com/lostisland/faraday-net_http/blob/f36ed44a18b64fdc883c050e3bd56b23ea0d2bc6/lib/faraday/adapter/net_http.rb#L190).

Last, here's a third-party implementation that I've stumbled upon that uses Faraday through the `ruby-openai` gem and [always expects a string response](https://github.com/patterns-ai-core/langchainrb/blob/ca95d11b7b026659e6a0fc57f7453a07fe92a27f/lib/langchain/llm/openai.rb#L176).


## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- Breaking change.

Not sure how you would categorize this change.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [X] I added tests for my changes.
- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
