### PR TITLE
Implement Response Information of the new Streaming API

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -179,19 +179,19 @@ module Async
 								response = env.stream_response do |&on_data|
 									response = client.call(request)
 									
+									save_response(env, response.status, nil, response.headers, finished: false)
+									
 									response.each do |chunk|
 										on_data.call(chunk)
 									end
 									
 									response
 								end
-								
-								save_response(env, response.status, nil, response.headers)
 							else
 								response = client.call(request)
-								
-								save_response(env, response.status, encoded_body(response), response.headers)
 							end
+							
+							save_response(env, response.status, encoded_body(response), response.headers)
 						end
 					end
 					

--- a/test/async/http/faraday/adapter.rb
+++ b/test/async/http/faraday/adapter.rb
@@ -198,16 +198,20 @@ describe Async::HTTP::Faraday::Adapter do
 					builder.adapter :async_http
 				end
 				
-				chunks = []
+				streamed = []
+				env = nil
 				
 				response = client.get(bound_url) do |request|
-					request.options.on_data = proc do |chunk|
-						chunks << chunk
+					request.options.on_data = proc do |chunk, size, block_env|
+						streamed << [chunk, size]
+						env ||= block_env
 					end
 				end
 				
-				expect(response.body).to be_nil
-				expect(chunks).to be == ["chunk0", "chunk1", "chunk2"]
+				expect(response.body).to be(:empty?)
+				expect(streamed).to be == [["chunk0", 6], ["chunk1", 12], ["chunk2", 18]]
+				expect(env).to be_a(Faraday::Env)
+				expect(env.status).to be == 200
 			end
 		end
 	end

--- a/test/async/http/faraday/adapter.rb
+++ b/test/async/http/faraday/adapter.rb
@@ -211,7 +211,7 @@ describe Async::HTTP::Faraday::Adapter do
 				expect(response.body).to be(:empty?)
 				expect(streamed).to be == [["chunk0", 6], ["chunk1", 12], ["chunk2", 18]]
 				expect(env).to be_a(Faraday::Env)
-				expect(env.status).to be == 200
+				expect(env).to have_attributes(status: be == 200)
 			end
 		end
 	end


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

With [Faraday v2.5.0](https://github.com/lostisland/faraday/releases/tag/v2.5.0), a [new streaming API has been introduced](https://github.com/lostisland/faraday/pull/1439) which allows adapters to provide response information to the `on_call` block. Acknowledging that not all adapters will implement this change immediately, the adapter specification [skipped the related tests](https://github.com/lostisland/faraday/blob/a9cf00425e3abc99b78952af44deb2912a65a882/spec/support/shared_examples/request_method.rb#L166-L168) in the initial release of this change. This PR implements the new adapter specification for async-http-faraday, including populating response information during streaming, resolving #48.

This implementation updates `env` with a response marked unfinished immediately after the request, in the same way the "reference implementation" of [the faraday-net_http adapter is doing it](https://github.com/lostisland/faraday-net_http/blob/f36ed44a18b64fdc883c050e3bd56b23ea0d2bc6/lib/faraday/adapter/net_http.rb#L122-L124). Moreover, the streaming tests have been adapted to [the adapter specification tests](https://github.com/lostisland/faraday/blob/a9cf00425e3abc99b78952af44deb2912a65a882/spec/support/shared_examples/request_method.rb#L151-L192).

Last, it assumes #47. 

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- Breaking change.

Not sure if this can be considered a bug.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [X] I added tests for my changes.
- [X] I tested my changes locally.
- [X] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
