### PR TITLE
Ignore Content-Length from env.request_headers

### DIFF
--- a/lib/async/http/faraday/adapter.rb
+++ b/lib/async/http/faraday/adapter.rb
@@ -111,7 +111,7 @@ module Async
 					SocketError
 				].freeze
 				
-				# Create a Farady compatible adapter.
+				# Create a Faraday compatible adapter.
 				# 
 				# @parameter timeout [Integer] The timeout for requests.
 				# @parameter options [Hash] Additional options to pass to the underlying Async::HTTP::Client.
@@ -181,6 +181,12 @@ module Async
 						end
 						
 						if headers = env.request_headers
+              # Ignore Content-Length if given, it will be set for us later anyway (lowercased)
+              if headers.has_key?("Content-Length")
+                headers = headers.dup
+                headers.delete("Content-Length")
+              end
+              
 							headers = ::Protocol::HTTP::Headers[headers]
 						end
 						


### PR DESCRIPTION
Closes #51

This makes the adapter ignore `Content-Length` if given in Faraday's `env.request_headers`, but only if capitalized, since `Async::HTTP` will set `content-length` anyway.

I'd like to add tests too, but I wasn't sure how to test what headers end up in the final request without setting up a dummy server to receive them. Any suggestions?