### PR TITLE
Fix invalid thread local usage in `#close`.

### DIFF
--- a/lib/async/http/faraday/clients.rb
+++ b/lib/async/http/faraday/clients.rb
@@ -177,10 +177,10 @@ module Async
 				# This will close all clients associated with all threads.
 				def close
 					Thread.list.each do |thread|
-						if clients = thread[@key]
-							clients.close
+						if clients = thread.thread_variable_get(@key)
+							thread.thread_variable_set(@key, nil)
 							
-							thread[@key] = nil
+							clients.close
 						end
 					end
 				end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Fix memory leak in `Async::HTTP::Faraday::PerThreadPersistentClients` by ensuring that the `close` method is called on all clients when the adapter is closed.
+
 ## v0.21.0
 
 ### Improved support for `timeout` and `read_timeout`.

--- a/test/async/http/faraday/clients.rb
+++ b/test/async/http/faraday/clients.rb
@@ -57,4 +57,33 @@ describe Async::HTTP::Faraday::PersistentClients do
 			end
 		end
 	end
+	
+	with "#close" do
+		it "closes all clients" do
+			endpoint = Async::HTTP::Endpoint.parse("http://example.com")
+			client = clients.make_client(endpoint)
+			expect(client).to receive(:close)
+			
+			clients.close
+		end
+	end
+end
+
+describe Async::HTTP::Faraday::PerThreadPersistentClients do
+	let(:clients) {subject.new}
+	
+	with "#close" do
+		it "closes all clients" do
+			endpoint = Async::HTTP::Endpoint.parse("http://example.com")
+			closed = false
+			
+			clients.with_client(endpoint) do |client|
+				expect(client).to receive(:close, &proc{closed = true})
+			end
+			
+			expect(closed).to be == false
+			clients.close
+			expect(closed).to be == true
+		end
+	end
 end


### PR DESCRIPTION
See <https://github.com/socketry/async-http-faraday/pull/57> for context.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
