### PR TITLE
Use structured multipart header fields

### DIFF
--- a/test/async/http/faraday/adapter.rb
+++ b/test/async/http/faraday/adapter.rb
@@ -285,8 +285,7 @@ describe Async::HTTP::Faraday::Adapter do
 				
 				parser.each do |part|
 					# Extract the field name from Content-Disposition header
-					if part.headers["content-disposition"] =~ /name="([^"]+)"/
-						name = $1
+					if name = part.headers["content-disposition"]["name"]
 						content = String.new
 						part.each{|chunk| content << chunk}
 						files[name] = content


### PR DESCRIPTION
## Summary

- read the multipart field name from the structured Content-Disposition header
- keep the multipart adapter integration test compatible with protocol-multipart 0.7.0

## Verification

- bundle exec bake test
- bundle exec rubocop