### PR TITLE
Close persistent proxy clients in dependency order

### DIFF
--- a/lib/async/http/faraday/clients.rb
+++ b/lib/async/http/faraday/clients.rb
@@ -86,7 +86,7 @@ module Async
 					clients = @clients.values
 					@clients.clear
 					
-					clients.each(&:close)
+					clients.reverse_each(&:close)
 				end
 				
 				# Lookup or create a client for the given endpoint.

--- a/test/async/http/faraday/clients.rb
+++ b/test/async/http/faraday/clients.rb
@@ -6,6 +6,72 @@
 require "async/http/faraday/clients"
 require "async/http/middleware/location_redirector"
 
+require "sus/fixtures/async/http/server_context"
+
+require "socket"
+
+class ConnectProxy
+	def initialize
+		@server = TCPServer.new("127.0.0.1", 0)
+		@workers = []
+		@thread = Thread.new do
+			loop do
+				client = @server.accept
+				@workers << Thread.new{tunnel(client)}
+			end
+		rescue IOError, Errno::EBADF
+			# The server was closed.
+		end
+	end
+	
+	def endpoint
+		Async::HTTP::Endpoint.parse("http://127.0.0.1:#{@server.local_address.ip_port}")
+	end
+	
+	def close
+		@server.close
+		@thread.join
+		@workers.each(&:join)
+	end
+	
+	private
+	
+	def tunnel(client)
+		request = client.gets
+		return unless request&.start_with?("CONNECT ")
+		
+		authority = request.split(" ", 3)[1]
+		host, port = authority.split(":", 2)
+		
+		while (line = client.gets) && line != "\r\n"
+		end
+		
+		upstream = TCPSocket.new(host, port)
+		client.write("HTTP/1.1 200 Connection established\r\n\r\n")
+		
+		copy(client, upstream)
+	ensure
+		client&.close
+		upstream&.close
+	end
+	
+	def copy(client, upstream)
+		pump = lambda do |input, output|
+			Thread.new do
+				IO.copy_stream(input, output)
+			rescue IOError, SystemCallError
+				# Either side of the tunnel was closed.
+			ensure
+				output.close_write rescue nil
+			end
+		end
+		
+		threads = [pump.call(client, upstream), pump.call(upstream, client)]
+		
+		threads.each(&:join)
+	end
+end
+
 describe Async::HTTP::Faraday::PersistentClients do
 	let(:clients) {subject.new}
 	
@@ -65,6 +131,31 @@ describe Async::HTTP::Faraday::PersistentClients do
 			expect(client).to receive(:close)
 			
 			clients.close
+		end
+		
+		with "a CONNECT proxy" do
+			include Sus::Fixtures::Async::HTTP::ServerContext
+			
+			it "closes the tunnel before the proxy client" do
+				proxy = ConnectProxy.new
+				endpoint = Async::HTTP::Endpoint.parse(bound_url)
+				closed = false
+				
+				clients.with_proxied_client(proxy.endpoint, endpoint) do |client|
+					response = client.get("/")
+					expect(response.read).to be == "Hello World!"
+				end
+				
+				cached_clients = clients.instance_variable_get(:@clients).values
+				
+				Async::Task.current.with_timeout(1) do
+					clients.close
+					closed = true
+				end
+			ensure
+				cached_clients&.reverse_each(&:close) unless closed
+				proxy&.close
+			end
 		end
 	end
 end


### PR DESCRIPTION
## Summary

- add a regression test using a real local HTTP server and CONNECT proxy
- close cached clients in reverse insertion order so tunnelled clients close before the proxy clients they depend on

A CONNECT tunnel remains an active request on the proxy client until the tunnelled client closes. `Client#close` waits for active requests to drain, but `PersistentClients` inserted the proxy client before the tunnelled client and then closed in insertion order. That made shutdown wait on the CONNECT request before closing the client that could finish it.

This addresses the deterministic persistent-client shutdown deadlock isolated while investigating #59.

## Verification

- regression test fails on the first commit with `Async::TimeoutError` in `Async::Pool::Controller#wait_until_free`
- `bundle exec sus` — 28 examples, 138 assertions
- `bundle exec rubocop lib/async/http/faraday/clients.rb test/async/http/faraday/clients.rb`